### PR TITLE
v0.3.3 update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,13 +59,13 @@ jobs:
         if: runner.os=='Windows'
         run: |
           cd external/Texconv-Custom-DLL/batch_files
-          ./build_small.bat
+          ./build.bat
       
       - name: build shared library (for Unix)
         if: runner.os!='Windows'
         run: |
           cd external/Texconv-Custom-DLL/shell_scripts
-          bash build_small.sh
+          bash build.sh
 
       - name: Copy files
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,13 +66,13 @@ jobs:
       - name: build dll (for Windows)
         if: runner.os=='Windows'
         run: |
-          external/Texconv-Custom-DLL/batch_files/build_small.bat
+          external/Texconv-Custom-DLL/batch_files/build.bat
           cp external/Texconv-Custom-DLL/texconv.dll addons/blender_dds_addon/directx
       
       - name: build shared library (for Unix)
         if: runner.os!='Windows'
         run: |
-          bash external/Texconv-Custom-DLL/shell_scripts/build_small.sh
+          bash external/Texconv-Custom-DLL/shell_scripts/build.sh
           cp external/Texconv-Custom-DLL/libtexconv.* addons/blender_dds_addon/directx
       
       - name: Set up Python v${{ env.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,9 +37,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Test with 2.83, 3.3, and 3.5 on Windows
+          # Test with 2.83, 3.3, and 3.6 on Windows
           - platform: windows-latest
-            blender-version: '3.5.1'
+            blender-version: '3.6.5'
           
           - platform: windows-latest
             blender-version: '3.3.7'

--- a/addons/blender_dds_addon/__init__.py
+++ b/addons/blender_dds_addon/__init__.py
@@ -8,7 +8,7 @@ from .directx.texconv import unload_texconv
 bl_info = {
     'name': 'DDS textures',
     'author': 'Matyalatte',
-    'version': (0, 3, 2),
+    'version': (0, 3, 3),
     'blender': (2, 83, 20),
     'location': 'Image Editor > Sidebar > DDS Tab',
     'description': 'Import and export .dds files',

--- a/addons/blender_dds_addon/directx/texconv.py
+++ b/addons/blender_dds_addon/directx/texconv.py
@@ -74,13 +74,12 @@ class Texconv:
                 raise RuntimeError(f'This OS ({util.get_os_name()}) is unsupported.')
             dirname = os.path.dirname(file_path)
             dll_path = os.path.join(dirname, dll_name)
-            dll_path2 = os.path.join(os.path.dirname(dirname), dll_name)  # allow ../texconv.dll
+
+            if util.is_arm():
+                raise RuntimeError(f'{dll_name} does NOT support ARM devices')
 
         if not os.path.exists(dll_path):
-            if os.path.exists(dll_path2):
-                dll_path = dll_path2
-            else:
-                raise RuntimeError(f'texconv not found. ({dll_path})')
+            raise RuntimeError(f'texconv not found. ({dll_path})')
 
         self.dll = ctypes.cdll.LoadLibrary(dll_path)
         DLL = self.dll

--- a/addons/blender_dds_addon/directx/texconv.py
+++ b/addons/blender_dds_addon/directx/texconv.py
@@ -205,8 +205,7 @@ class Texconv:
         if out not in ['.', ''] and not os.path.exists(out):
             util.mkdir(out)
 
-        args += ["-y"]
-        args += [os.path.normpath(file)]
+        args += ["-y", "--", os.path.normpath(file)]
 
         args_p = [ctypes.c_wchar_p(arg) for arg in args]
         args_p = (ctypes.c_wchar_p*len(args_p))(*args_p)
@@ -235,7 +234,7 @@ class Texconv:
         out = os.path.dirname(new_file)
         if out not in ['.', ''] and not os.path.exists(out):
             util.mkdir(out)
-        args += ["-y", "-o", new_file, file]
+        args += ["-y", "-o", new_file, "--", file]
 
         args_p = [ctypes.c_wchar_p(arg) for arg in args]
         args_p = (ctypes.c_wchar_p*len(args_p))(*args_p)

--- a/addons/blender_dds_addon/directx/texconv.py
+++ b/addons/blender_dds_addon/directx/texconv.py
@@ -176,6 +176,9 @@ class Texconv:
         if image_filter != "LINEAR":
             args += ["-if", image_filter]
 
+        if "SRGB" in dds_fmt:
+            args += ['-srgb']
+
         if ("BC5" in dds_fmt) and invert_normals:
             args += ['-inverty']
 

--- a/addons/blender_dds_addon/directx/util.py
+++ b/addons/blender_dds_addon/directx/util.py
@@ -36,3 +36,7 @@ def is_linux():
 
 def is_mac():
     return get_os_name() == 'Darwin'
+
+
+def is_arm():
+    return 'arm' in platform.machine().lower()

--- a/addons/blender_dds_addon/ui/export_dds.py
+++ b/addons/blender_dds_addon/ui/export_dds.py
@@ -13,7 +13,7 @@ from bpy_extras.io_utils import ExportHelper
 import numpy as np
 
 from ..directx.dds import is_hdr, DDS
-from ..directx.texconv import Texconv
+from ..directx.texconv import Texconv, unload_texconv
 from .bpy_util import save_texture, dds_properties_exist, get_image_editor_space, flush_stdout
 from .texture_list import draw_texture_list
 
@@ -266,6 +266,10 @@ class DDS_OT_export_base(Operator):
             print(traceback.format_exc())
             self.report({'ERROR'}, e.args[0])
             ret = {'CANCELLED'}
+
+        # release DLL resources
+        unload_texconv()
+
         return ret
 
 

--- a/addons/blender_dds_addon/ui/import_dds.py
+++ b/addons/blender_dds_addon/ui/import_dds.py
@@ -13,7 +13,7 @@ from bpy_extras.io_utils import ImportHelper
 import numpy as np
 
 from ..directx.dds import DDSHeader, DDS
-from ..directx.texconv import Texconv
+from ..directx.texconv import Texconv, unload_texconv
 from .bpy_util import get_image_editor_space, load_texture, dds_properties_exist, flush_stdout
 from .custom_properties import DDS_FMT_NAMES
 
@@ -183,6 +183,9 @@ class DDS_OT_import_base(Operator):
             print(traceback.format_exc())
             self.report({'ERROR'}, e.args[0])
             ret = {'CANCELLED'}
+
+        # release DLL resources
+        unload_texconv()
 
         return ret
 

--- a/addons/blender_dds_addon/ui/import_dds.py
+++ b/addons/blender_dds_addon/ui/import_dds.py
@@ -131,10 +131,11 @@ def import_dds(context, file):
 def import_dds_rec(context, folder, count=0):
     """Search a folder recursively, and import found dds files."""
     for file in sorted(os.listdir(folder)):
-        if os.path.isdir(file):
-            count += import_dds_rec(context, os.path.join(folder, file), count=count)
+        path = os.path.join(folder, file)
+        if os.path.isdir(path):
+            count += import_dds_rec(context, path, count=count)
         elif file.split('.')[-1].lower() == "dds":
-            import_dds(context, os.path.join(folder, file))
+            import_dds(context, path)
             count += 1
     return count
 

--- a/addons/blender_dds_addon/ui/import_dds.py
+++ b/addons/blender_dds_addon/ui/import_dds.py
@@ -128,12 +128,13 @@ def import_dds(context, file):
         space.image = tex
 
 
-def import_dds_rec(context, folder, count=0):
+def import_dds_rec(context, folder):
     """Search a folder recursively, and import found dds files."""
+    count = 0
     for file in sorted(os.listdir(folder)):
         path = os.path.join(folder, file)
         if os.path.isdir(path):
-            count += import_dds_rec(context, path, count=count)
+            count += import_dds_rec(context, path)
         elif file.split('.')[-1].lower() == "dds":
             import_dds(context, path)
             count += 1

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ ver 0.3.3
 - Fixed a bug that sRGB formats make textures brighter when exporting.
 - Fixed an error when importing files from some specific directory structures.
 - Fixed a bug that the `Import from a Directory` operation can not count DDS files correctly.
+- Fixed an error when releasing DLL resources on Linux.
 - Made the addon release DLL resources for each operation.
 - Added an error for ARM devices.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+ver 0.3.3
+- Fixed an error when importing files from some specific directory structures.
+
 ver 0.3.2
 - Fixed an error when importing dds without image editor opened.
 - Fixed an error when changing workspace with file picker opened.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ ver 0.3.3
 - Fixed a crash when closing Blender after exporting BC6 or BC7 textures.
 - Fixed a bug that sRGB formats make textures brighter when exporting.
 - Fixed an error when importing files from some specific directory structures.
+- Fixed a bug that the `Import from a Directory` operation can not count DDS files correctly.
 - Made the addon release DLL resources for each operation.
 - Added an error for ARM devices.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 ver 0.3.3
 - Fixed a crash when closing Blender after exporting BC6 or BC7 textures.
+- Fixed a bug that sRGB formats make textures brighter when exporting.
 - Fixed an error when importing files from some specific directory structures.
 
 ver 0.3.2

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ ver 0.3.3
 - Fixed a crash when closing Blender after exporting BC6 or BC7 textures.
 - Fixed a bug that sRGB formats make textures brighter when exporting.
 - Fixed an error when importing files from some specific directory structures.
+- Added an error for ARM devices.
 
 ver 0.3.2
 - Fixed an error when importing dds without image editor opened.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 ver 0.3.3
+- Fixed a crash when closing Blender after exporting BC6 or BC7 textures.
 - Fixed an error when importing files from some specific directory structures.
 
 ver 0.3.2

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ ver 0.3.3
 - Fixed a crash when closing Blender after exporting BC6 or BC7 textures.
 - Fixed a bug that sRGB formats make textures brighter when exporting.
 - Fixed an error when importing files from some specific directory structures.
+- Made the addon release DLL resources for each operation.
 - Added an error for ARM devices.
 
 ver 0.3.2

--- a/docs/How-To-Build.md
+++ b/docs/How-To-Build.md
@@ -41,13 +41,13 @@ It'll download the file and place it in a proper location.
 ### for Windows
 
 Move to `./Blender-DDS-Addon/external/Texconv-Custom-DLL/batch_files`.  
-Then, type `build_small.bat`.  
+Then, type `build.bat`.  
 `texconv.dll` will be generated in `./Blender-DDS-Addon/external/Texconv-Custom-DLL/`  
 
 ### for Unix/Linux
 
 Move to `./Blender-DDS-Addon/external/Texconv-Custom-DLL/shell_scripts`.  
-Then, type `bash build_small.sh`.  
+Then, type `bash build.sh`.  
 `libtexconv.so` (or `libtexconv.dylib`) will be generated in `./Blender-DDS-Addon/external/Texconv-Custom-DLL/`  
 
 ## 4. Copy Texconv

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Blender-DDS-Addon v0.3.2
+# Blender-DDS-Addon v0.3.3
 
 [![Github All Releases](https://img.shields.io/github/downloads/matyalatte/Blender-DDS-Addon/total.svg)]()
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,6 @@
 [![Github All Releases](https://img.shields.io/github/downloads/matyalatte/Blender-DDS-Addon/total.svg)]()
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 ![build](https://github.com/matyalatte/Blender-DDS-Addon/actions/workflows/build.yml/badge.svg)
-<a href="https://www.buymeacoffee.com/matyalatteQ" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="41" width="174"></a>  
 
 Blender addon to import and export dds textures  
   
@@ -22,11 +21,9 @@ You can download zip files from [the release page](https://github.com/matyalatte
 
 -   `blender_dds_addon*_Windows.zip` is for Windows.
 -   `blender_dds_addon*_macOS.zip` is for Mac (10.15 or later).
--   `blender_dds_addon*_Linux.zip` is for Ubuntu (20.04 or later).
+-   `blender_dds_addon*_Linux.zip` is for Linux with GLIBC 2.27+ and GLIBCXX 3.4.26+.
 
-> The linux build only supports Ubuntu due to the glibc dependences.  
-> If you want to use it on other linux distributions, you should get the lib or build [Texconv](https://github.com/matyalatte/Texconv-Custom-DLL) by yourself.  
-> (But I don't know if it's possible on your platform.)  
+> The linux build only supports distributions using GLIBC and GLIBCXX.  
 
 ## Getting Started
 
@@ -118,7 +115,7 @@ Here is a list of supported formats.
 
 </details>
 
-## About Non-2D Textures
+## Non-2D Textures
 The addon supports non-2D textures except for partial cubemaps.  
 See wiki pages for the details.  
 

--- a/tests/test_dds.py
+++ b/tests/test_dds.py
@@ -6,12 +6,15 @@ from blender_dds_addon.ui import (import_dds,
                                   export_dds,
                                   texture_list,
                                   custom_properties)
-from blender_dds_addon.directx.texconv import unload_texconv
+from blender_dds_addon.directx.texconv import Texconv, unload_texconv
 import bpy
 
 bpy.utils.register_class(texture_list.DDSTextureListItem)
 bpy.utils.register_class(custom_properties.DDSCustomProperties)
 custom_properties.add_custom_props_for_dds()
+
+texconv = Texconv()
+texconv.dll.init_com()
 
 
 def get_test_dds():


### PR DESCRIPTION
closes #10 and closes #11 

- Fixed a crash when closing Blender after exporting BC6 or BC7 textures. (https://github.com/matyalatte/Texconv-Custom-DLL/commit/a9d196f8eda577c633ec29d1ee360968626813ef)
- Fixed a bug that sRGB formats make textures brighter when exporting. (https://github.com/matyalatte/Blender-DDS-Addon/commit/5cf72c1c6751d8072e50cd119d4fd44d3ca4239e)
- Fixed an error when importing files from some specific directory structures. (19225a1617db715e197e0b55513d3eb4cd2ff70d)
- Fixed a bug that the `Import from a Directory` operation can not count DDS files correctly. (efad51f52a627aec2ccb5d8d3ab9086ac83c2983)
- Fixed an error when releasing DLL resources on Linux. (89cbb05e2ecfb113d67a3a0e433c9f82479d19d6)
- The addon will release DLL resources for each operation. (0db4c68c6badbe9c7ce779d42c29d91f74353fbd)
- Added an error for ARM devices. (be560160f997b2b2b346bce425c9379ced61b883)
- Added Blender 3.6.5 to test environments (9c0d1be398e26d4c119334c7ca54ca8d4988ff0e)