### PR TITLE
v0.3.4 update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
   test:
     # Most code is from pytest-blender's workflow by mondeja.
     # https://github.com/mondeja/pytest-blender/blob/master/.github/workflows/ci.yml
-    name: Test
+    name: Test-${{ matrix.platform }}-${{ matrix.blender-version }}
     runs-on: ${{ matrix.platform }}
     env:
       pytest-version: '7.1.2'
@@ -37,22 +37,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Test with 2.83, 3.3, and 3.6 on Windows
+          # Test with 2.83, 3.3, 3.6, and 4.0 on Windows
           - platform: windows-latest
-            blender-version: '3.6.5'
-          
+            blender-version: '4.0.2'
+
           - platform: windows-latest
-            blender-version: '3.3.7'
+            blender-version: '3.6.7'
+
+          - platform: windows-latest
+            blender-version: '3.3.14'
           
           - platform: windows-latest
             blender-version: '2.83.20'
           
-          # Test with 3.3 on Unix/Linux systems
+          # Test with 3.6 on Unix/Linux systems
           - platform: ubuntu-latest
-            blender-version: '3.3.7'
+            blender-version: '3.6.7'
           
           - platform: macos-latest
-            blender-version: '3.3.7'
+            blender-version: '3.6.7'
 
     steps:
       - uses: actions/checkout@v3

--- a/addons/blender_dds_addon/__init__.py
+++ b/addons/blender_dds_addon/__init__.py
@@ -8,7 +8,7 @@ from .directx.texconv import unload_texconv
 bl_info = {
     'name': 'DDS textures',
     'author': 'Matyalatte',
-    'version': (0, 3, 3),
+    'version': (0, 3, 4),
     'blender': (2, 83, 20),
     'location': 'Image Editor > Sidebar > DDS Tab',
     'description': 'Import and export .dds files',

--- a/addons/blender_dds_addon/directx/dds.py
+++ b/addons/blender_dds_addon/directx/dds.py
@@ -251,7 +251,11 @@ class DX10Header(c.LittleEndianStructure):
 
 
 def is_hdr(name: str):
-    return 'BC6' in name or 'FLOAT' in name or 'INT' in name or 'SNORM' in name
+    return 'BC6' in name or 'FLOAT' in name or 'INT' in name
+
+
+def is_signed(name: str):
+    return 'SNORM' in name or 'SF16' in name
 
 
 def convertible_to_tga(name: str):
@@ -389,6 +393,9 @@ class DDSHeader(c.LittleEndianStructure):
 
     def is_int(self):
         return 'INT' in self.dxgi_format.name
+
+    def is_signed(self):
+        return is_signed(self.dxgi_format.name)
 
     def is_canonical(self):
         return self.fourCC not in UNCANONICAL_FOURCC

--- a/addons/blender_dds_addon/directx/texconv.py
+++ b/addons/blender_dds_addon/directx/texconv.py
@@ -9,7 +9,7 @@ from ctypes.util import find_library
 import os
 import tempfile
 
-from .dds import DDSHeader, is_hdr
+from .dds import DDSHeader, is_hdr, is_signed
 from .dxgi_format import DXGI_FORMAT
 from . import util
 
@@ -131,6 +131,9 @@ class Texconv:
             if not dds_header.convertible_to_tga():
                 args += ['-f', 'rgba']
 
+        if dds_header.is_signed():
+            args += '-x2bias'
+
         if dds_header.is_int():
             msg = f'Int format detected. ({dds_header.get_format_as_str()})\n It might not be converted correctly.'
             print(msg)
@@ -139,7 +142,8 @@ class Texconv:
             args += ['-ft', fmt]
 
             if dds_header.is_bc5():
-                args += ['-reconstructz']
+                if not dds_header.is_signed():
+                    args += ['-reconstructz']
                 if invert_normals:
                     args += ['-inverty']
 
@@ -184,6 +188,9 @@ class Texconv:
             args += ['-m', '1']
         if image_filter != "LINEAR":
             args += ["-if", image_filter]
+
+        if is_signed(dds_fmt):
+            args += '-x2bias'
 
         if "SRGB" in dds_fmt:
             args += ['-srgb']

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+ver 0.3.4
+- Fixed a bug that SNORM textures are broken when importing and exporting.
+
 ver 0.3.3
 - Fixed a crash when closing Blender after exporting BC6 or BC7 textures.
 - Fixed a bug that sRGB formats make textures brighter when exporting.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Blender-DDS-Addon v0.3.3
+# Blender-DDS-Addon v0.3.4
 
 [![Github All Releases](https://img.shields.io/github/downloads/matyalatte/Blender-DDS-Addon/total.svg)]()
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
closes #14 

- Fixed a bug that SNORM textures are broken when importing.
- Update Blender versions for testing.

Current test environments

| OS | Blender |
| -- | -- |
| Windows | 4.0.2 |
| Windows | 3.6.7 |
| Windows | 3.3.14 |
| Windows | 2.83.20 |
| Ubuntu | 3.6.7 |
| macOS | 3.6.7 |
