### PR TITLE
Unload DLLs only when disabling addon

### DIFF
--- a/addons/blender_dds_addon/ui/drag_drop.py
+++ b/addons/blender_dds_addon/ui/drag_drop.py
@@ -4,8 +4,8 @@ import traceback
 
 import bpy
 from .import_dds import import_dds
-from ..directx.texconv import Texconv, unload_texconv
-from ..astcenc.astcenc import Astcenc, unload_astcenc
+from ..directx.texconv import Texconv
+from ..astcenc.astcenc import Astcenc
 from .bpy_util import flush_stdout
 
 
@@ -58,10 +58,6 @@ class DDS_OT_drag_drop_import(bpy.types.Operator):
             print(traceback.format_exc())
             self.report({'ERROR'}, e.args[0])
             ret = {'CANCELLED'}
-
-        # release DLL resources
-        unload_texconv()
-        unload_astcenc()
 
         return ret
 

--- a/addons/blender_dds_addon/ui/export_dds.py
+++ b/addons/blender_dds_addon/ui/export_dds.py
@@ -13,8 +13,8 @@ import numpy as np
 
 from ..directx.dds import is_hdr, DDS, DDSHeader
 from ..directx.dxgi_format import DXGI_FORMAT
-from ..directx.texconv import Texconv, unload_texconv
-from ..astcenc.astcenc import Astcenc, unload_astcenc
+from ..directx.texconv import Texconv
+from ..astcenc.astcenc import Astcenc
 from .bpy_util import (save_texture, texture_to_buffer, dxgi_to_dtype,
                        dds_properties_exist, get_image_editor_space, flush_stdout)
 from .texture_list import draw_texture_list
@@ -298,10 +298,6 @@ class DDS_OT_export_base(Operator):
             print(traceback.format_exc())
             self.report({'ERROR'}, e.args[0])
             ret = {'CANCELLED'}
-
-        # release DLL resources
-        unload_texconv()
-        unload_astcenc()
 
         return ret
 

--- a/addons/blender_dds_addon/ui/import_dds.py
+++ b/addons/blender_dds_addon/ui/import_dds.py
@@ -13,8 +13,8 @@ from bpy_extras.io_utils import ImportHelper
 import numpy as np
 
 from ..directx.dds import DDSHeader, DDS
-from ..directx.texconv import Texconv, unload_texconv
-from ..astcenc.astcenc import Astcenc, unload_astcenc
+from ..directx.texconv import Texconv
+from ..astcenc.astcenc import Astcenc
 from .bpy_util import (get_image_editor_space,
                        load_texture, load_texture_from_buffer,
                        dds_properties_exist, flush_stdout, dxgi_to_dtype)
@@ -226,10 +226,6 @@ class DDS_OT_import_base(Operator):
             print(traceback.format_exc())
             self.report({'ERROR'}, e.args[0])
             ret = {'CANCELLED'}
-
-        # release DLL resources
-        unload_texconv()
-        unload_astcenc()
 
         return ret
 


### PR DESCRIPTION
Related to #33.

DDS addon now unload DLLs only when disabling the addon.
Idk why but Blender 4.5 crashes when unloading DLLs in the export operation.