### PR TITLE
Use sRGB as default color space, add import options for color space

### DIFF
--- a/addons/blender_dds_addon/ui/custom_properties.py
+++ b/addons/blender_dds_addon/ui/custom_properties.py
@@ -77,6 +77,24 @@ class DDSPropBase:
     list_index: IntProperty(name="An extra texture for texture arrays or volume textures", default=0)
 
 
+def colorspace_items():
+    """Dynamically list all available color spaces from Blender"""
+    items = []
+    for cs in bpy.types.Image.bl_rna.properties['colorspace_settings'] \
+                .fixed_type.properties['name'].enum_items:
+        items.append((cs.identifier, cs.name, cs.description))
+    return items
+
+def colorspace_hdr_default():
+    """Get default colorspace for HDR textures"""
+    items = []
+    for cs in bpy.types.Image.bl_rna.properties['colorspace_settings'] \
+                .fixed_type.properties['name'].enum_items:
+        if cs.identifier in ('Linear Rec.709', 'Linear'):
+            return cs.identifier
+    return 'Non-Color'
+
+
 class DDSOptions(DDSPropBase, PropertyGroup):
     """Properties for operations."""
     dxgi_format: EnumProperty(
@@ -110,6 +128,19 @@ class DDSOptions(DDSPropBase, PropertyGroup):
         default=False,
     )
 
+    colorspace: EnumProperty(
+        name="Color Space",
+        description="Color space for LDR textures",
+        items=colorspace_items(),
+        default='sRGB'
+    )
+
+    colorspace_hdr: EnumProperty(
+        name="HDR Color Space",
+        description="Color space for HDR textures",
+        items=colorspace_items(),
+        default=colorspace_hdr_default()
+    )
 
 class DDSCustomProperties(DDSPropBase, PropertyGroup):
     """Properties for dds info."""

--- a/addons/blender_dds_addon/ui/import_dds.py
+++ b/addons/blender_dds_addon/ui/import_dds.py
@@ -45,6 +45,7 @@ def load_dds_via_tga(texconv, file, out_dir, cubemap_layout='h-cross', invert_no
 
 
 def load_dds(file, invert_normals=False, cubemap_layout='h-cross',
+             colorspace_ldr='sRGB', colorspace_hdr='Non-Color',
              texconv=None, astcenc=None):
     """Import a texture form .dds file.
 
@@ -52,6 +53,8 @@ def load_dds(file, invert_normals=False, cubemap_layout='h-cross',
         file (string): file path to .dds file
         invert_normals (bool): Flip y axis if the texture is normal map.
         cubemap_layout (string): Layout for cubemap faces.
+        colorspace_ldr: Color space for LDR textures.
+        colorspace_hdr: Color space for HDR textures.
         texconv (Texconv): Texture converter for dds.
         astcenc (Astcenc): Astc converter.
 
@@ -78,10 +81,10 @@ def load_dds(file, invert_normals=False, cubemap_layout='h-cross',
                 dds.save(temp)
 
             # Check dxgi_format
-            if dds_header.is_srgb():
-                color_space = 'sRGB'
+            if dds_header.is_hdr():
+                color_space = colorspace_hdr
             else:
-                color_space = 'Non-Color'
+                color_space = colorspace_ldr
 
             fmt = dds_header.get_format_as_str()
 
@@ -160,6 +163,7 @@ def import_dds(context, file, texconv=None, astcenc=None):
     dds_options = context.scene.dds_options
     tex = load_dds(file, invert_normals=dds_options.invert_normals,
                    cubemap_layout=dds_options.cubemap_layout,
+                   colorspace_ldr=dds_options.colorspace, colorspace_hdr=dds_options.colorspace_hdr,
                    texconv=texconv, astcenc=astcenc)
     if space:
         space.image = tex
@@ -189,6 +193,8 @@ class DDS_OT_import_base(Operator):
         dds_options = context.scene.dds_options
         layout.prop(dds_options, 'invert_normals')
         layout.prop(dds_options, 'cubemap_layout')
+        layout.prop(dds_options, 'colorspace')
+        layout.prop(dds_options, 'colorspace_hdr')
 
     def execute_base(self, context, files=None, directory=None, is_dir=False):
         if directory is None:
@@ -287,6 +293,8 @@ class DDS_PT_import_panel(bpy.types.Panel):
         dds_options = context.scene.dds_options
         layout.prop(dds_options, 'invert_normals')
         layout.prop(dds_options, 'cubemap_layout')
+        layout.prop(dds_options, 'colorspace')
+        layout.prop(dds_options, 'colorspace_hdr')
 
 
 classes = (


### PR DESCRIPTION
Blender DDS Addon now uses `sRGB` as the color space of LDR textures and uses `Linear Rec.709` as the color space of HDR textures.
You can also change the default color spaces from DDS panel.

<img width="347" height="219" alt="colorspace" src="https://github.com/user-attachments/assets/014e31af-7c34-4d1d-9791-f9617e565681" />
