### PR TITLE
v0.5.0 release

### DIFF
--- a/addons/blender_dds_addon/__init__.py
+++ b/addons/blender_dds_addon/__init__.py
@@ -10,7 +10,7 @@ from .astcenc.astcenc import unload_astcenc
 bl_info = {
     'name': 'DDS textures',
     'author': 'Matyalatte',
-    'version': (0, 4, 3),
+    'version': (0, 5, 0),
     'blender': (2, 83, 20),
     'location': 'Image Editor > Sidebar > DDS Tab',
     'description': 'Import and export .dds files',

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,14 @@
+ver 0.5.0
+- Fixed a crash in Blender 4.5 after exporting textures. (#34)
+- Added options to change the color space of imported textures. (#37)
+  The DDS addon now defaults LDR textures to sRGB.
+- Added an option to handle premultiplied alpha. (#38)
+- Added support for Windows on ARM64. (#36)
+- Updated submodules. (#35)
+  - DirectXTex: from June2024 to July2025.
+  - astc-encoder: from 4.8.0 to 5.3.0.
+- Options are now grouped in collapsible boxes. (#39)
+
 ver 0.4.3
 - Fixed a bug where DLL changed locale settings on Windows.
 

--- a/docs/How-To-Build.md
+++ b/docs/How-To-Build.md
@@ -29,7 +29,7 @@ Copy the built binary (`texconv.dll`, `libtexconv.dylib` or `libtexconv.so`) to 
 
 ## 5. Build astc-encoder
 
-Move to `C:\Users\nk0902\git\Blender-DDS-Addon\external`.  
+Move to `./Blender-DDS-Addon/external`.  
 Then, run `build_astcenc.bat`, `build_astcenc_Linux.sh`, or `build_astcenc_macOS.sh`.  
 It generates `astcenc-*.dll` or `libastcenc-*.*` in `./Blender-DDS-Addon/external/astc-encoder/`  
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Blender-DDS-Addon v0.4.3
+# Blender-DDS-Addon v0.5.0
 
 [![Github All Releases](https://img.shields.io/github/downloads/matyalatte/Blender-DDS-Addon/total.svg)]()
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@
 
 Blender addon to import and export dds textures  
   
-![Screenshot](https://user-images.githubusercontent.com/69258547/194742234-9021612e-a49e-4b92-a92c-234678b7a298.png)  
+![Screenshot](https://github.com/user-attachments/assets/1e799e6c-ba5e-48b9-bbf4-0908fc5b4c54)  
 
 ## Features
 
@@ -14,16 +14,15 @@ Blender addon to import and export dds textures
 - Export textures as DDS
 - Support many DXGI formats (including BC6, BC7, and ASTC)
 - Support non-2D textures (cubemaps, arrays, and volume textures)
+- Some utilities (invert normals, edit texture arrays, etc.)
 
 ## Download
 
 You can download zip files from [the release page](https://github.com/matyalatte/Blender-DDS-Addon/releases).  
 
--   `blender_dds_addon*_Windows.zip` is for Windows.
+-   `blender_dds_addon*_Windows-*.zip` is for Windows.
 -   `blender_dds_addon*_macOS.zip` is for Mac (10.15 or later).
--   `blender_dds_addon*_Linux.zip` is for Linux with GLIBC 2.27+ and GLIBCXX 3.4.26+.
-
-> The linux build only supports distributions using GLIBC and GLIBCXX.  
+-   `blender_dds_addon*_Linux-x64.zip` is for Linux with GLIBC 2.27+ and GLIBCXX 3.4.26+.
 
 ## Getting Started
 
@@ -156,9 +155,7 @@ See wiki pages for the details.
 ### Texconv-Custom-DLL
 
 [Texconv](https://github.com/microsoft/DirectXTex/wiki/Texconv)
-is a texture converter developed by Microsoft.  
-It's the best DDS converter as far as I know.  
-And [Texconv-Custom-DLL](https://github.com/matyalatte/Texconv-Custom-DLL) is a cross-platform implementation I made.  
+is a texture converter developed by Microsoft, and [Texconv-Custom-DLL](https://github.com/matyalatte/Texconv-Custom-DLL) is a cross-platform implementation I made.  
 The official Texconv only supports Windows but you can use it on Unix/Linux systems.  
 It is released under the [MIT license](../LICENSE).
 


### PR DESCRIPTION
- Fixed a crash in Blender 4.5 after exporting textures. (#34)
- Added options to change the color space of imported textures. (#37)
  The DDS addon now defaults LDR textures to sRGB.
- Added an option to handle premultiplied alpha. (#38)
- Added support for Windows on ARM64. (#36)
- Updated submodules. (#35)
  - DirectXTex: from June2024 to [July2025](https://github.com/microsoft/DirectXTex/releases/tag/jul2025).
  - astc-encoder: from 4.8.0 to [5.3.0](https://github.com/ARM-software/astc-encoder/releases/tag/5.3.0).
- Options are now grouped in collapsible boxes. (#39)