### PR TITLE
make shell scripts executable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,9 +70,9 @@ jobs:
       - name: build shared library (for macOS)
         if: runner.os=='macOS'
         run: |
-          bash external/Texconv-Custom-DLL/shell_scripts/build_universal.sh
+          ./external/Texconv-Custom-DLL/shell_scripts/build_universal.sh
           cp external/Texconv-Custom-DLL/libtexconv.* addons/blender_dds_addon/directx
-          bash external/build_astcenc_macOS.sh
+          ./external/build_astcenc_macOS.sh
           cp external/astc-encoder/libastcenc* addons/blender_dds_addon/astcenc
 
       - name: build shared library (for Linux)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,9 +91,9 @@ jobs:
       - name: build shared library (for Unix)
         if: runner.os!='Windows'
         run: |
-          bash external/Texconv-Custom-DLL/shell_scripts/build_universal.sh
+          ./external/Texconv-Custom-DLL/shell_scripts/build_universal.sh
           cp external/Texconv-Custom-DLL/libtexconv.* addons/blender_dds_addon/directx
-          bash external/build_astcenc_${{ runner.os }}.sh
+          ./external/build_astcenc_${{ runner.os }}.sh
           cp external/astc-encoder/libastcenc* addons/blender_dds_addon/astcenc
 
       - name: Set up Python v${{ env.python-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN git submodule update --init --recursive --recommend-shallow --depth 1
 # Build
 WORKDIR /Blender-DDS-Addon
 RUN mkdir bin && \
-    bash external/Texconv-Custom-DLL/shell_scripts/build.sh && \
+    ./external/Texconv-Custom-DLL/shell_scripts/build.sh && \
     cp external/Texconv-Custom-DLL/libtexconv.* bin && \
-    bash external/build_astcenc_Linux.sh && \
+    ./external/build_astcenc_Linux.sh && \
     cp external/astc-encoder/libastcenc* bin

--- a/external/build_astcenc_Linux.sh
+++ b/external/build_astcenc_Linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Builds astc-encoder with cmake on Linux.
 # libastc-sse2-shared.so will be generated in ./astc-encoder/
 

--- a/external/build_astcenc_macOS.sh
+++ b/external/build_astcenc_macOS.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Builds astc-encoder with cmake on macOS.
 # libastc-shared.dylib will be generated in ./astc-encoder/
 


### PR DESCRIPTION
You can now run shell scripts as executables without the `bash` command.