### PR TITLE
show an error message when running arm64 build on x64 machine

### DIFF
--- a/addons/blender_dds_addon/ui/bpy_util.py
+++ b/addons/blender_dds_addon/ui/bpy_util.py
@@ -1,4 +1,7 @@
 import os
+import platform
+import traceback
+
 import bpy
 import numpy as np
 
@@ -151,3 +154,22 @@ def dxgi_to_dtype(fmt):
     if fmt == "R16G16B16A16_FLOAT":
         return np.float16
     raise RuntimeError(f"dxgi_to_dtype() does not support {fmt}.")
+
+
+def get_os_error_msg(exception):
+    # Get an error message for OS errors.
+    if platform.system() == 'Windows' and exception.winerror == 193:
+        # Invalid architecture
+        if platform.machine().lower() == 'arm64':
+            machine_arch = 'arm64'
+            addon_arch = 'x64'
+        else:
+            machine_arch = 'x64'
+            addon_arch = 'arm64'
+        msg = f"{addon_arch} build does not work on your machine. Get {machine_arch} version of the DDS addon."
+        print(f"Error: {msg}")
+    else:
+        # Unexpected error
+        print(traceback.format_exc())
+        msg = exception.args[0]
+    return msg

--- a/addons/blender_dds_addon/ui/drag_drop.py
+++ b/addons/blender_dds_addon/ui/drag_drop.py
@@ -6,7 +6,7 @@ import bpy
 from .import_dds import import_dds
 from ..directx.texconv import Texconv
 from ..astcenc.astcenc import Astcenc
-from .bpy_util import flush_stdout
+from .bpy_util import flush_stdout, get_os_error_msg
 
 
 def is_dds_panel(context):
@@ -30,10 +30,9 @@ class DDS_OT_drag_drop_import(bpy.types.Operator):
         if not self.directory or not self.files:
             return {'CANCELLED'}
 
-        texconv = Texconv()
-        astcenc = Astcenc()
-
         try:
+            texconv = Texconv()
+            astcenc = Astcenc()
             start_time = time.time()
             count = 0
 
@@ -54,7 +53,14 @@ class DDS_OT_drag_drop_import(bpy.types.Operator):
             self.report({'INFO'}, m)
             ret = {'FINISHED'}
 
+        except OSError as e:
+            # Maybe arm64 build is running on x64 machine.
+            msg = get_os_error_msg(e)
+            self.report({'ERROR'}, msg)
+            ret = {'CANCELLED'}
+
         except Exception as e:
+            # Unexpected error
             print(traceback.format_exc())
             self.report({'ERROR'}, e.args[0])
             ret = {'CANCELLED'}


### PR DESCRIPTION
The current version raises `OSError: [WinError 193]` when running arm64 version on x64 Windows.

This PR uses a more understandable message instead.
 `arm64 build does not work on your machine. Get x64 version of the DDS addon.`